### PR TITLE
Disable providers access to TimeManager app

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -95,6 +95,9 @@ class PageController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	function index(string $userFilter = "") {
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
+			return;
+
 		// Find the latest time entries
 		$times = $this->timeMapper->findActiveForCurrentUser("start", true, "DESC");
 		$all_clients = $this->clientMapper->findActiveForCurrentUser("name", true);
@@ -168,7 +171,10 @@ class PageController extends Controller {
 		string $end = "",
 		string $format = "none",
 		string $userFilter = ""
-	) {
+	) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
+			return;
+
 		$start_of_month = new \DateTime("first day of this month");
 		$end_of_month = new \DateTime("last day of this month");
 		// Fall back to default if date is invalid
@@ -323,7 +329,10 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
-	function clients() {
+	function clients() {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
+			return;
+
 		$clients = $this->clientMapper->findActiveForCurrentUser("name", true);
 
 		$urlGenerator = \OC::$server->getURLGenerator();
@@ -483,7 +492,10 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
-	function projects($client = null) {
+	function projects($client = null) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
+			return;
+
 		$clients = $this->clientMapper->findActiveForCurrentUser("created", true);
 		$isSingleClient = false;
 		if ($client) {
@@ -671,6 +683,9 @@ class PageController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	function tasks($project) {
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
+			return;
+
 		$clients = $this->clientMapper->findActiveForCurrentUser("created", true);
 		$projects = $this->projectMapper->findActiveForCurrentUser("created", true);
 		$sharedBy = null;
@@ -871,6 +886,9 @@ class PageController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	function times($task, string $userFilter = "") {
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
+			return;
+			
 		$clients = $this->clientMapper->findActiveForCurrentUser("created", true);
 		$projects = $this->projectMapper->findActiveForCurrentUser("created", true);
 		$tasks = $this->taskMapper->findActiveForCurrentUser("created", true);

--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -95,8 +95,8 @@ class PageController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	function index(string $userFilter = "") {
-		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
-			return;
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))		
+			return new RedirectResponse('/apps/adminly_dashboard');
 
 		// Find the latest time entries
 		$times = $this->timeMapper->findActiveForCurrentUser("start", true, "DESC");
@@ -172,8 +172,8 @@ class PageController extends Controller {
 		string $format = "none",
 		string $userFilter = ""
 	) {		
-		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
-			return;
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 
 		$start_of_month = new \DateTime("first day of this month");
 		$end_of_month = new \DateTime("last day of this month");
@@ -330,8 +330,8 @@ class PageController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	function clients() {		
-		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
-			return;
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 
 		$clients = $this->clientMapper->findActiveForCurrentUser("name", true);
 
@@ -393,7 +393,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function addClient($name = "Unnamed", $note = "") {
+	function addClient($name = "Unnamed", $note = "") {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		$this->storageHelper->addOrUpdateObject(
@@ -411,7 +413,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function deleteClient($uuid) {
+	function deleteClient($uuid) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		// Get client
@@ -432,7 +436,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function editClient($uuid, $name = "Unnamed", $note = "") {
+	function editClient($uuid, $name = "Unnamed", $note = "") {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$client = $this->clientMapper->getActiveObjectById($uuid);
 		if ($client) {
@@ -455,7 +461,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function addClientShare($client_uuid, $user_id) {
+	function addClientShare($client_uuid, $user_id) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$client = $this->clientMapper->getActiveObjectById($client_uuid);
 		// User must be author if we can get the client
 		if ($client) {
@@ -478,7 +486,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function deleteClientShare($uuid, $client_uuid) {
+	function deleteClientShare($uuid, $client_uuid) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$shares = $this->shareMapper->findByUuid($uuid);
 		if (count($shares) > 0) {
 			$this->shareMapper->delete($shares[0]);
@@ -492,9 +502,9 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
-	function projects($client = null) {		
-		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
-			return;
+	function projects($client = null) {				
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 
 		$clients = $this->clientMapper->findActiveForCurrentUser("created", true);
 		$isSingleClient = false;
@@ -617,7 +627,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function addProject($name, $client) {
+	function addProject($name, $client) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		$this->storageHelper->addOrUpdateObject(
@@ -635,7 +647,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function deleteProject($uuid, $client) {
+	function deleteProject($uuid, $client) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		// Get client
@@ -659,7 +673,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function editProject($uuid, $name = "Unnamed") {
+	function editProject($uuid, $name = "Unnamed") {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$project = $this->projectMapper->getActiveObjectById($uuid);
 		if ($project) {
@@ -682,9 +698,9 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
-	function tasks($project) {
-		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
-			return;
+	function tasks($project) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 
 		$clients = $this->clientMapper->findActiveForCurrentUser("created", true);
 		$projects = $this->projectMapper->findActiveForCurrentUser("created", true);
@@ -820,7 +836,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function addTask($name, $project) {
+	function addTask($name, $project) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		$this->storageHelper->addOrUpdateObject(
@@ -838,7 +856,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function deleteTask($uuid, $project) {
+	function deleteTask($uuid, $project) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		// Get task
@@ -862,7 +882,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function editTask($uuid, $name = "Unnamed") {
+	function editTask($uuid, $name = "Unnamed") {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$task = $this->taskMapper->getActiveObjectById($uuid);
 		if ($task) {
@@ -885,9 +907,9 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
-	function times($task, string $userFilter = "") {
-		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))
-			return;
+	function times($task, string $userFilter = "") {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 			
 		$clients = $this->clientMapper->findActiveForCurrentUser("created", true);
 		$projects = $this->projectMapper->findActiveForCurrentUser("created", true);
@@ -1012,7 +1034,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function addTime($duration, $date, $note, $task) {
+	function addTime($duration, $date, $note, $task) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		// Convert 1,25 to 1.25
@@ -1044,7 +1068,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function deleteTime($uuid) {
+	function deleteTime($uuid) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
 		if ($time) {
 			$commit = UUID::v4();
@@ -1070,7 +1096,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function editTime($uuid, $duration, $date, $note) {
+	function editTime($uuid, $duration, $date, $note) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
 		if ($time) {
 			$commit = UUID::v4();
@@ -1121,7 +1149,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function payTime($uuid) {
+	function payTime($uuid) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
 		if ($time) {
 			$commit = UUID::v4();
@@ -1144,7 +1174,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function unpayTime($uuid) {
+	function unpayTime($uuid) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
 		if ($time) {
 			$commit = UUID::v4();
@@ -1167,7 +1199,9 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	function updateSettings($handle_conflicts) {
+	function updateSettings($handle_conflicts) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$this->config->setAppValue(
 			"timemanager",
 			"sync_mode",
@@ -1181,7 +1215,9 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
-	function tools() {
+	function tools() {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return new RedirectResponse('/apps/adminly_dashboard');
 		$all_clients = $this->clientMapper->findActiveForCurrentUser("name");
 		$all_projects = $this->projectMapper->findActiveForCurrentUser("name");
 		$all_tasks = $this->taskMapper->findActiveForCurrentUser("name");

--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -22,6 +22,7 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\IRequest;
 use OCP\IConfig;
 use OCP\IUserManager;
+use OCP\IURLGenerator;
 
 class PageController extends Controller {
 	/** @var ClientMapper mapper for client entity */
@@ -44,6 +45,8 @@ class PageController extends Controller {
 	private $config;
 	/** @var IUserManager */
 	private $userManager;
+	/** @var IURLGenerator */
+	private $urlGenerator;
 
 	/**
 	 * constructor of the controller
@@ -66,6 +69,7 @@ class PageController extends Controller {
 		ShareMapper $shareMapper,
 		IConfig $config,
 		IUserManager $userManager,
+		IURLGenerator $urlGenerator,
 		$userId
 	) {
 		parent::__construct($appName, $request);
@@ -78,6 +82,7 @@ class PageController extends Controller {
 		$this->userId = $userId;
 		$this->config = $config;
 		$this->userManager = $userManager;
+		$this->urlGenerator = $urlGenerator;
 		$this->storageHelper = new StorageHelper(
 			$this->clientMapper,
 			$this->projectMapper,
@@ -95,8 +100,9 @@ class PageController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	function index(string $userFilter = "") {
+		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))		
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 
 		// Find the latest time entries
 		$times = $this->timeMapper->findActiveForCurrentUser("start", true, "DESC");
@@ -104,7 +110,7 @@ class PageController extends Controller {
 		$all_projects = $this->projectMapper->findActiveForCurrentUser("name", true);
 		$all_tasks = $this->taskMapper->findActiveForCurrentUser("name", true);
 
-		$urlGenerator = \OC::$server->getURLGenerator();
+		
 		$requestToken = \OC::$server->getSession() ? \OCP\Util::callRegister() : "";
 
 		$times = $this->storageHelper->resolveAuthorDisplayNamesForTimes($times, $this->userManager);
@@ -144,9 +150,9 @@ class PageController extends Controller {
 					return ["value" => $oneTask["uuid"], "label" => $oneTask["name"], "projectUuid" => $oneTask["project_uuid"]];
 				}, $all_tasks),
 				"initialDate" => date("Y-m-d"),
-				"action" => $urlGenerator->linkToRoute("timemanager.page.times"),
-				"statsApiUrl" => $urlGenerator->linkToRoute("timemanager.t_api.getHoursInPeriodStats"),
-				"settingsAction" => $urlGenerator->linkToRoute("timemanager.page.updateSettings"),
+				"action" => $this->urlGenerator->linkToRoute("timemanager.page.times"),
+				"statsApiUrl" => $this->urlGenerator->linkToRoute("timemanager.t_api.getHoursInPeriodStats"),
+				"settingsAction" => $this->urlGenerator->linkToRoute("timemanager.page.updateSettings"),
 				"settings" => [
 					"handle_conflicts" =>
 						$this->config->getAppValue("timemanager", "sync_mode", "force_skip_conflict_handling") ===
@@ -173,7 +179,7 @@ class PageController extends Controller {
 		string $userFilter = ""
 	) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 
 		$start_of_month = new \DateTime("first day of this month");
 		$end_of_month = new \DateTime("last day of this month");
@@ -266,7 +272,7 @@ class PageController extends Controller {
 			// Download as CSV
 			return new DataDownloadResponse(ArrayToCSV::convert($all_time_entries), $filename, "text/csv");
 		} else {
-			$urlGenerator = \OC::$server->getURLGenerator();
+			
 			$requestToken = \OC::$server->getSession() ? \OCP\Util::callRegister() : "";
 
 			$store = [
@@ -287,8 +293,8 @@ class PageController extends Controller {
 					return ["value" => $oneTask["uuid"], "label" => $oneTask["name"], "projectUuid" => $oneTask["project_uuid"]];
 				}, $all_tasks),
 				"initialDate" => date("Y-m-d"),
-				"action" => $urlGenerator->linkToRoute("timemanager.page.reports"),
-				"statsApiUrl" => $urlGenerator->linkToRoute("timemanager.t_api.getHoursInPeriodStats"),
+				"action" => $this->urlGenerator->linkToRoute("timemanager.page.reports"),
+				"statsApiUrl" => $this->urlGenerator->linkToRoute("timemanager.t_api.getHoursInPeriodStats"),
 				"requestToken" => $requestToken,
 				"isServer" => true,
 				"startOfMonth" => $start_of_month->format("Y-m-d"),
@@ -296,7 +302,7 @@ class PageController extends Controller {
 				"start" => $start,
 				"end" => $end,
 				"controls" => false,
-				"settingsAction" => $urlGenerator->linkToRoute("timemanager.page.updateSettings"),
+				"settingsAction" => $this->urlGenerator->linkToRoute("timemanager.page.updateSettings"),
 				"settings" => [
 					"handle_conflicts" =>
 						$this->config->getAppValue("timemanager", "sync_mode", "force_skip_conflict_handling") ===
@@ -331,16 +337,16 @@ class PageController extends Controller {
 	 */
 	function clients() {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 
 		$clients = $this->clientMapper->findActiveForCurrentUser("name", true);
 
-		$urlGenerator = \OC::$server->getURLGenerator();
+		
 		$requestToken = \OC::$server->getSession() ? \OCP\Util::callRegister() : "";
 		$l = \OC::$server->getL10N("timemanager");
 
 		$form_props = [
-			"action" => $urlGenerator->linkToRoute("timemanager.page.clients"),
+			"action" => $this->urlGenerator->linkToRoute("timemanager.page.clients"),
 			"requestToken" => $requestToken,
 			"isServer" => true,
 		];
@@ -369,8 +375,8 @@ class PageController extends Controller {
 		}
 
 		$form_props = [
-			"action" => $urlGenerator->linkToRoute("timemanager.page.clients"),
-			"settingsAction" => $urlGenerator->linkToRoute("timemanager.page.updateSettings"),
+			"action" => $this->urlGenerator->linkToRoute("timemanager.page.clients"),
+			"settingsAction" => $this->urlGenerator->linkToRoute("timemanager.page.updateSettings"),
 			"settings" => [
 				"handle_conflicts" =>
 					$this->config->getAppValue("timemanager", "sync_mode", "force_skip_conflict_handling") === "handle_conflicts",
@@ -395,7 +401,7 @@ class PageController extends Controller {
 	 */
 	function addClient($name = "Unnamed", $note = "") {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		$this->storageHelper->addOrUpdateObject(
@@ -406,8 +412,8 @@ class PageController extends Controller {
 			],
 			"clients"
 		);
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.clients"));
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.clients"));
 	}
 
 	/**
@@ -415,7 +421,7 @@ class PageController extends Controller {
 	 */
 	function deleteClient($uuid) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		// Get client
@@ -429,8 +435,8 @@ class PageController extends Controller {
 		// Delete children
 		$this->clientMapper->deleteChildrenForEntityById($uuid, $commit);
 
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.clients"));
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.clients"));
 	}
 
 	/**
@@ -438,7 +444,7 @@ class PageController extends Controller {
 	 */
 	function editClient($uuid, $name = "Unnamed", $note = "") {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$client = $this->clientMapper->getActiveObjectById($uuid);
 		if ($client) {
@@ -454,8 +460,8 @@ class PageController extends Controller {
 				"clients"
 			);
 		}
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $uuid);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $uuid);
 	}
 
 	/**
@@ -463,7 +469,7 @@ class PageController extends Controller {
 	 */
 	function addClientShare($client_uuid, $user_id) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$client = $this->clientMapper->getActiveObjectById($client_uuid);
 		// User must be author if we can get the client
 		if ($client) {
@@ -479,8 +485,8 @@ class PageController extends Controller {
 			$this->shareMapper->insert($share);
 		}
 
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client_uuid);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client_uuid);
 	}
 
 	/**
@@ -488,14 +494,14 @@ class PageController extends Controller {
 	 */
 	function deleteClientShare($uuid, $client_uuid) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$shares = $this->shareMapper->findByUuid($uuid);
 		if (count($shares) > 0) {
 			$this->shareMapper->delete($shares[0]);
 		}
 
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client_uuid);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client_uuid);
 	}
 
 	/**
@@ -504,7 +510,7 @@ class PageController extends Controller {
 	 */
 	function projects($client = null) {				
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 
 		$clients = $this->clientMapper->findActiveForCurrentUser("created", true);
 		$isSingleClient = false;
@@ -553,7 +559,7 @@ class PageController extends Controller {
 			}
 		}
 
-		$urlGenerator = \OC::$server->getURLGenerator();
+		
 		$requestToken = \OC::$server->getSession() ? \OCP\Util::callRegister() : "";
 		$l = \OC::$server->getL10N("timemanager");
 
@@ -573,9 +579,9 @@ class PageController extends Controller {
 		}
 
 		$form_props = [
-			"action" => $urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client_uuid,
-			"editAction" => $urlGenerator->linkToRoute("timemanager.page.clients"),
-			"settingsAction" => $urlGenerator->linkToRoute("timemanager.page.updateSettings"),
+			"action" => $this->urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client_uuid,
+			"editAction" => $this->urlGenerator->linkToRoute("timemanager.page.clients"),
+			"settingsAction" => $this->urlGenerator->linkToRoute("timemanager.page.updateSettings"),
 			"settings" => [
 				"handle_conflicts" =>
 					$this->config->getAppValue("timemanager", "sync_mode", "force_skip_conflict_handling") === "handle_conflicts",
@@ -591,15 +597,15 @@ class PageController extends Controller {
 				"name" => $client_name,
 				"note" => isset($client_data) && count($client_data) > 0 ? $client_data[0]->getNote() : "",
 			],
-			"deleteAction" => $urlGenerator->linkToRoute("timemanager.page.clients") . "/delete",
+			"deleteAction" => $this->urlGenerator->linkToRoute("timemanager.page.clients") . "/delete",
 			"deleteUuid" => $client_uuid,
 			"deleteButtonCaption" => $l->t("Delete client"),
 			"deleteQuestion" => $l->t(
 				"Do you want to delete the client %s and all associated projects, tasks and time entries?",
 				[$client_name]
 			),
-			"shareAction" => $urlGenerator->linkToRoute("timemanager.page.clients") . "/share",
-			"deleteShareAction" => $urlGenerator->linkToRoute("timemanager.page.clients") . "/share/delete",
+			"shareAction" => $this->urlGenerator->linkToRoute("timemanager.page.clients") . "/share",
+			"deleteShareAction" => $this->urlGenerator->linkToRoute("timemanager.page.clients") . "/share/delete",
 			"sharees" => $sharees,
 			"sharedBy" => $sharedBy,
 			"canEdit" => $sharedBy === null,
@@ -629,7 +635,7 @@ class PageController extends Controller {
 	 */
 	function addProject($name, $client) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		$this->storageHelper->addOrUpdateObject(
@@ -640,8 +646,8 @@ class PageController extends Controller {
 			],
 			"projects"
 		);
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client);
 	}
 
 	/**
@@ -649,7 +655,7 @@ class PageController extends Controller {
 	 */
 	function deleteProject($uuid, $client) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		// Get client
@@ -666,8 +672,8 @@ class PageController extends Controller {
 			$this->projectMapper->deleteChildrenForEntityById($uuid, $commit);
 		}
 
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.projects") . "?client=" . $client);
 	}
 
 	/**
@@ -675,7 +681,7 @@ class PageController extends Controller {
 	 */
 	function editProject($uuid, $name = "Unnamed") {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$project = $this->projectMapper->getActiveObjectById($uuid);
 		if ($project) {
@@ -690,8 +696,8 @@ class PageController extends Controller {
 				"projects"
 			);
 		}
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.tasks") . "?project=" . $uuid);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.tasks") . "?project=" . $uuid);
 	}
 
 	/**
@@ -700,7 +706,7 @@ class PageController extends Controller {
 	 */
 	function tasks($project) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 
 		$clients = $this->clientMapper->findActiveForCurrentUser("created", true);
 		$projects = $this->projectMapper->findActiveForCurrentUser("created", true);
@@ -777,7 +783,7 @@ class PageController extends Controller {
 			}
 		}
 
-		$urlGenerator = \OC::$server->getURLGenerator();
+		
 		$requestToken = \OC::$server->getSession() ? \OCP\Util::callRegister() : "";
 		$l = \OC::$server->getL10N("timemanager");
 
@@ -785,9 +791,9 @@ class PageController extends Controller {
 		$project_name = isset($project_data) && count($project_data) > 0 ? $project_data[0]->getName() : "";
 
 		$form_props = [
-			"action" => $urlGenerator->linkToRoute("timemanager.page.tasks") . "?project=" . $project_uuid,
-			"editAction" => $urlGenerator->linkToRoute("timemanager.page.projects"),
-			"settingsAction" => $urlGenerator->linkToRoute("timemanager.page.updateSettings"),
+			"action" => $this->urlGenerator->linkToRoute("timemanager.page.tasks") . "?project=" . $project_uuid,
+			"editAction" => $this->urlGenerator->linkToRoute("timemanager.page.projects"),
+			"settingsAction" => $this->urlGenerator->linkToRoute("timemanager.page.updateSettings"),
 			"settings" => [
 				"handle_conflicts" =>
 					$this->config->getAppValue("timemanager", "sync_mode", "force_skip_conflict_handling") === "handle_conflicts",
@@ -800,7 +806,7 @@ class PageController extends Controller {
 			"projectUuid" => $project_uuid,
 			"taskEditorButtonCaption" => $l->t("Add task"),
 			"taskEditorCaption" => $l->t("New task"),
-			"deleteAction" => $urlGenerator->linkToRoute("timemanager.page.projects") . "/delete",
+			"deleteAction" => $this->urlGenerator->linkToRoute("timemanager.page.projects") . "/delete",
 			"deleteUuid" => $project_uuid,
 			"deleteButtonCaption" => $l->t("Delete project"),
 			"deleteQuestion" => $l->t("Do you want to delete the project %s and all associated tasks and time entries?", [
@@ -838,7 +844,7 @@ class PageController extends Controller {
 	 */
 	function addTask($name, $project) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		$this->storageHelper->addOrUpdateObject(
@@ -849,8 +855,8 @@ class PageController extends Controller {
 			],
 			"tasks"
 		);
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.tasks") . "?project=" . $project);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.tasks") . "?project=" . $project);
 	}
 
 	/**
@@ -858,7 +864,7 @@ class PageController extends Controller {
 	 */
 	function deleteTask($uuid, $project) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		// Get task
@@ -875,8 +881,8 @@ class PageController extends Controller {
 			$this->taskMapper->deleteChildrenForEntityById($uuid, $commit);
 		}
 
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.tasks") . "?project=" . $project);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.tasks") . "?project=" . $project);
 	}
 
 	/**
@@ -884,7 +890,7 @@ class PageController extends Controller {
 	 */
 	function editTask($uuid, $name = "Unnamed") {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$task = $this->taskMapper->getActiveObjectById($uuid);
 		if ($task) {
@@ -899,8 +905,8 @@ class PageController extends Controller {
 				"tasks"
 			);
 		}
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $uuid);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $uuid);
 	}
 
 	/**
@@ -909,7 +915,7 @@ class PageController extends Controller {
 	 */
 	function times($task, string $userFilter = "") {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 			
 		$clients = $this->clientMapper->findActiveForCurrentUser("created", true);
 		$projects = $this->projectMapper->findActiveForCurrentUser("created", true);
@@ -969,7 +975,7 @@ class PageController extends Controller {
 		});
 		$hasSharedTimeEntries = count($sharedTimeEntries) > 0;
 
-		$urlGenerator = \OC::$server->getURLGenerator();
+		
 		$requestToken = \OC::$server->getSession() ? \OCP\Util::callRegister() : "";
 		$l = \OC::$server->getL10N("timemanager");
 
@@ -977,9 +983,9 @@ class PageController extends Controller {
 		$task_name = isset($task_data) && count($task_data) > 0 ? $task_data[0]->getName() : "";
 
 		$form_props = [
-			"action" => $urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $task_uuid,
-			"editAction" => $urlGenerator->linkToRoute("timemanager.page.tasks"),
-			"settingsAction" => $urlGenerator->linkToRoute("timemanager.page.updateSettings"),
+			"action" => $this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $task_uuid,
+			"editAction" => $this->urlGenerator->linkToRoute("timemanager.page.tasks"),
+			"settingsAction" => $this->urlGenerator->linkToRoute("timemanager.page.updateSettings"),
 			"settings" => [
 				"handle_conflicts" =>
 					$this->config->getAppValue("timemanager", "sync_mode", "force_skip_conflict_handling") === "handle_conflicts",
@@ -995,14 +1001,14 @@ class PageController extends Controller {
 			"editTaskData" => [
 				"name" => $task_name,
 			],
-			"deleteAction" => $urlGenerator->linkToRoute("timemanager.page.tasks") . "/delete",
+			"deleteAction" => $this->urlGenerator->linkToRoute("timemanager.page.tasks") . "/delete",
 			"deleteUuid" => $task_uuid,
 			"deleteButtonCaption" => $l->t("Delete task"),
 			"deleteQuestion" => $l->t("Do you want to delete the task %s and all associated time entries?", [$task_name]),
-			"deleteTimeEntryAction" => $urlGenerator->linkToRoute("timemanager.page.times") . "/delete",
+			"deleteTimeEntryAction" => $this->urlGenerator->linkToRoute("timemanager.page.times") . "/delete",
 			"timeEditorButtonCaption" => $l->t("Add time entry"),
 			"timeEditorCaption" => $l->t("New time entry"),
-			"editTimeEntryAction" => $urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $task_uuid,
+			"editTimeEntryAction" => $this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $task_uuid,
 			"sharedBy" => $sharedBy,
 			"sharees" => $sharees,
 			"canEdit" => $sharedBy === null,
@@ -1036,7 +1042,7 @@ class PageController extends Controller {
 	 */
 	function addTime($duration, $date, $note, $task) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$commit = UUID::v4();
 		$this->storageHelper->insertCommit($commit);
 		// Convert 1,25 to 1.25
@@ -1061,8 +1067,8 @@ class PageController extends Controller {
 			],
 			"times"
 		);
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $task);
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $task);
 	}
 
 	/**
@@ -1070,7 +1076,7 @@ class PageController extends Controller {
 	 */
 	function deleteTime($uuid) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
 		if ($time) {
 			$commit = UUID::v4();
@@ -1084,9 +1090,9 @@ class PageController extends Controller {
 			// Delete children
 			$this->timeMapper->deleteChildrenForEntityById($uuid, $commit);
 
-			$urlGenerator = \OC::$server->getURLGenerator();
+			
 			return new RedirectResponse(
-				$urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
+				$this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
 			);
 		}
 
@@ -1098,7 +1104,7 @@ class PageController extends Controller {
 	 */
 	function editTime($uuid, $duration, $date, $note) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
 		if ($time) {
 			$commit = UUID::v4();
@@ -1137,9 +1143,9 @@ class PageController extends Controller {
 			$time->setNote($note); // date + duration
 			$this->timeMapper->update($time);
 
-			$urlGenerator = \OC::$server->getURLGenerator();
+			
 			return new RedirectResponse(
-				$urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
+				$this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
 			);
 		}
 
@@ -1151,7 +1157,7 @@ class PageController extends Controller {
 	 */
 	function payTime($uuid) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
 		if ($time) {
 			$commit = UUID::v4();
@@ -1162,9 +1168,9 @@ class PageController extends Controller {
 			$time->setPaymentStatus("paid");
 			$this->timeMapper->update($time);
 
-			$urlGenerator = \OC::$server->getURLGenerator();
+			
 			return new RedirectResponse(
-				$urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
+				$this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
 			);
 		}
 
@@ -1176,7 +1182,7 @@ class PageController extends Controller {
 	 */
 	function unpayTime($uuid) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$time = $this->storageHelper->getTimeEntryByIdForEditing($uuid);
 		if ($time) {
 			$commit = UUID::v4();
@@ -1187,9 +1193,9 @@ class PageController extends Controller {
 			$time->setPaymentStatus("");
 			$this->timeMapper->update($time);
 
-			$urlGenerator = \OC::$server->getURLGenerator();
+			
 			return new RedirectResponse(
-				$urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
+				$this->urlGenerator->linkToRoute("timemanager.page.times") . "?task=" . $time->getTaskUuid()
 			);
 		}
 
@@ -1201,14 +1207,14 @@ class PageController extends Controller {
 	 */
 	function updateSettings($handle_conflicts) {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$this->config->setAppValue(
 			"timemanager",
 			"sync_mode",
 			(bool) $handle_conflicts ? "handle_conflicts" : "force_skip_conflict_handling"
 		);
-		$urlGenerator = \OC::$server->getURLGenerator();
-		return new RedirectResponse($urlGenerator->linkToRoute("timemanager.page.index"));
+		
+		return new RedirectResponse($this->urlGenerator->linkToRoute("timemanager.page.index"));
 	}
 
 	/**
@@ -1217,13 +1223,13 @@ class PageController extends Controller {
 	 */
 	function tools() {		
 		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
-			return new RedirectResponse('/apps/adminly_dashboard');
+			return new RedirectResponse($this->urlGenerator->getBaseUrl());
 		$all_clients = $this->clientMapper->findActiveForCurrentUser("name");
 		$all_projects = $this->projectMapper->findActiveForCurrentUser("name");
 		$all_tasks = $this->taskMapper->findActiveForCurrentUser("name");
 		$all_times = $this->timeMapper->findActiveForCurrentUser();
 
-		$urlGenerator = \OC::$server->getURLGenerator();
+		
 		$requestToken = \OC::$server->getSession() ? \OCP\Util::callRegister() : "";
 
 		$store = [
@@ -1231,11 +1237,11 @@ class PageController extends Controller {
 			"projects" => $all_projects,
 			"tasks" => $all_tasks,
 			"times" => $all_times,
-			"action" => $urlGenerator->linkToRoute("timemanager.page.tools"),
-			"syncApiUrl" => $urlGenerator->linkToRoute("timemanager.t_api.updateObjectsFromWeb"),
+			"action" => $this->urlGenerator->linkToRoute("timemanager.page.tools"),
+			"syncApiUrl" => $this->urlGenerator->linkToRoute("timemanager.t_api.updateObjectsFromWeb"),
 			"requestToken" => $requestToken,
 			"isServer" => true,
-			// "settingsAction" => $urlGenerator->linkToRoute("timemanager.page.updateSettings"),
+			// "settingsAction" => $this->urlGenerator->linkToRoute("timemanager.page.updateSettings"),
 			// "settings" => [
 			// 	"handle_conflicts" =>
 			// 		$this->config->getAppValue("timemanager", "sync_mode", "force_skip_conflict_handling") ===

--- a/controller/tapicontroller.php
+++ b/controller/tapicontroller.php
@@ -89,7 +89,9 @@ class TApiController extends ApiController {
 	 * @param string $note the note of the item
 	 * @return DataResponse
 	 */
-	function post($name, $note) {
+	function post($name, $note) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return;
 		$client = new Client();
 		$client->setName($name);
 		$client->setNote($note);
@@ -105,7 +107,9 @@ class TApiController extends ApiController {
 	 * @param json $data
 	 * @return DataResponse
 	 */
-	function updateObjectsFromWeb($data, $lastCommit) {
+	function updateObjectsFromWeb($data, $lastCommit) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return;
 		return $this->updateObjects($data, $lastCommit);
 	}
 
@@ -117,7 +121,9 @@ class TApiController extends ApiController {
 	 * @param json $data
 	 * @return DataResponse
 	 */
-	function updateObjects($data, $lastCommit) {
+	function updateObjects($data, $lastCommit) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return;
 		$logger = \OC::$server->getLogger();
 		$logger->debug("New API request:", ["app" => "timemanager"]);
 		$logger->debug(json_encode($data), ["app" => "timemanager"]);
@@ -236,7 +242,9 @@ class TApiController extends ApiController {
 		string $status = null,
 		$shared = false,
 		string $userFilter = ""
-	) {
+	) {		
+		if(\OC::$server->getGroupManager()->isInGroup($this->userId, "provider"))	
+			return;
 		// Get possible task ids to filters for
 		$filter_tasks = $this->storageHelper->getTaskListFromFilters($clients, $projects, $tasks, $shared);
 

--- a/css/timemanager.scss
+++ b/css/timemanager.scss
@@ -642,11 +642,6 @@ label {
 			}
 		}
 	}
-
-	#app-navigation,
-	#app-content {
-		margin-top: 6px !important;
-	}
 }
 
 .oc-dialog-buttonrow.reverse {

--- a/css/timemanager.scss
+++ b/css/timemanager.scss
@@ -642,6 +642,11 @@ label {
 			}
 		}
 	}
+
+	#app-navigation,
+	#app-content {
+		margin-top: 6px !important;
+	}
 }
 
 .oc-dialog-buttonrow.reverse {


### PR DESCRIPTION
### Changes
Disable providers access to TimeManager pages, as an extra step to removing the icon from the navbar. It's an extra security step so providers can't edit the VA time sheets.

### Testing
It shouldn't be possible to access the following pages when logged as a provider:
apps/timemanager/
apps/timemanager/tasks
apps/timemanager/projects
apps/timemanager/times
apps/timemanager/clients