### PR TITLE
Lower TimeManger app UI

### DIFF
--- a/css/timemanager.scss
+++ b/css/timemanager.scss
@@ -643,8 +643,7 @@ label {
 		}
 	}
 
-	#app-navigation,
-	#app-content {
+	#app-navigation {
 		margin-top: 6px !important;
 	}
 }

--- a/css/timemanager.scss
+++ b/css/timemanager.scss
@@ -644,7 +644,8 @@ label {
 	}
 
 	#app-navigation {
-		margin-top: 6px !important;
+		top: 56px;
+		height: calc(100% - 56px);
 	}
 }
 

--- a/css/timemanager.scss
+++ b/css/timemanager.scss
@@ -642,6 +642,11 @@ label {
 			}
 		}
 	}
+
+	#app-navigation,
+	#app-content {
+		margin-top: 6px !important;
+	}
 }
 
 .oc-dialog-buttonrow.reverse {


### PR DESCRIPTION
### Changes
Lower the app-navigation and app-content by 6px because of the increased height of the navbar.

### Testing
Open the TimeManager app and check if the following divs have a top margin of 6px:

- app-navigation 
- app-content